### PR TITLE
Testing: Initial Setup of Test Enviroment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 __pycache__
+venv/

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,12 @@ DOCKER_COMPOSE=docker-compose --env-file $(ENV_FILE) -f ./docker-compose.yml
 
 # Start containers
 up:
+	@echo "Creating your containers up..."
 	$(DOCKER_COMPOSE) up -d
 
 # Stop and remove containers
 down:
+	@echo "Stopping and removing your containers..."
 	$(DOCKER_COMPOSE) down
 
 # View logs
@@ -23,22 +25,27 @@ logs:
 
 # Start containers without rebuilding
 start:
+	@echo "Powering on your containers..."
 	$(DOCKER_COMPOSE) start && make logs
 
 # Stop containers
 stop:
+	@echo "Gracefully stopping your containers..."
 	$(DOCKER_COMPOSE) stop
 
 # Restart containers
 restart:
+	@echo "Restarting your existing containers..."
 	$(DOCKER_COMPOSE) restart
 
 # Rebuild containers
 rebuild:
+	@echo "Rebuilding your containers from the group up..."
 	$(DOCKER_COMPOSE) up --force-recreate --build --no-start
 
 # Remove all containers, networks, images, and volumes
 clean:
+	@echo "Removing your docker backend stack and cleaning images..."
 	$(DOCKER_COMPOSE) down --remove-orphans --rmi all -v
 
 # Start Flask in development mode (debug + hot reload)
@@ -68,11 +75,14 @@ upgrade:
 	docker exec -it flask_backend flask db upgrade
 
 seed:
+	@echo "Seeding docker database..."
 	docker exec -it flask_backend python -m app.seed
 
-# Run tests
+# Run tests inside Docker container using SQLite, will test any file with the name test_<something>.py
 test:
-	docker exec -it flask_backend pytest
+	@echo "Running unit tests inside Docker..."
+	docker exec -it flask_backend env PYTHONPATH=. APP_ENV=testing python3 -m unittest discover -s tests -p "test_*.py"
+
 
 #####################
 ## LOCAL COMMANDS ##
@@ -83,10 +93,12 @@ test:
 
 # Install dependencies (similar to a package.json)
 local-install:
+	@echo "Installing requirements.txt..."
 	pip install -r requirements.txt
 
 # Run Flask locally in development mode (hot reload)
 local-run:
+	@echo "Running the backend locally"
 	flask --app app --debug run
 
 # Enter Flask shell locally
@@ -101,12 +113,15 @@ local-migrate:
 
 # Apply the latest migrations to the database (Local)
 local-upgrade:
+	@echo "Applying local migrations..."
 	flask db upgrade
 
 # Seed database locally
 local-seed:
+	@echo "Seeding local database..."
 	python app/seed.py
 
 # Run tests locally
 local-test:
-	pytest
+	@echo "Running unit tests locally with SQLite..."
+	PYTHONPATH=. APP_ENV=testing python3 -m unittest discover -s tests -p "test_*.py"

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,15 +16,18 @@ def create_app():
     # Read environment flag (default to "local" if not set)
     app_env = os.getenv("APP_ENV", "local").lower()
 
-    # Switch between docker and local machine
+     # Switch between docker, testing, and local machine
     if app_env == "docker":
         database_url = os.getenv("DOCKER_DATABASE_URL", "postgresql://postgres:password@db:5432/postgres")
+    elif app_env == "testing":  # Use SQLite in-memory for testing
+        database_url = "sqlite:///:memory:"
     else:
         database_url = os.getenv("LOCAL_DATABASE_URL", "postgresql://postgres:password@localhost:5432/taskagotchi")
 
-    # Load configuration
+    # Load database config
     app.config["SQLALCHEMY_DATABASE_URI"] = database_url
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    app.config["TESTING"] = app_env == "testing"
 
     # Bind database to the app
     db.init_app(app)
@@ -44,3 +47,4 @@ app = create_app()
 
 print(f"⚡ Running in {os.getenv('APP_ENV', 'local').upper()} mode")
 print(f"🔌 Connected to database: {app.config['SQLALCHEMY_DATABASE_URI']}")
+print(f"🌍 Running on http://0.0.0.0:{os.getenv('FLASK_RUN_PORT', '5000')}")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# We just need this file to recognize tests as a module

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,0 +1,43 @@
+import unittest
+import os
+from app import create_app, db
+
+# Class for user testings
+class UserModelTestCase(unittest.TestCase):
+    def setUp(self):
+        # Sets up testing db
+        self.app = create_app()
+
+        # Override database for testing, force in memory sqlite3
+        self.app.config['SQLALCHEMY_DATABASE_URI'] = "sqlite:///:memory:"
+        self.app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+        self.app.config['TESTING'] = True
+
+        self.client = self.app.test_client()
+
+        with self.app.app_context():
+            db.create_all() # run the schema (migrations)
+
+    # After each test, tear it down
+    def tearDown(self):
+        with self.app.app_context():
+            db.session.remove()
+            db.drop_all()
+
+    # Test creating a new user
+    def test_user_creation(self):
+        with self.app.app_context():
+            from app.models import Users  #import inside the test context
+            # User info we are trying to add
+            user = Users(username="testuser", email="test@example.com")
+            # Attempt to add
+            db.session.add(user)
+            db.session.commit()
+            # Query
+            retrieved_user = Users.query.filter_by(username="testuser").first()
+            # Asserts
+            self.assertIsNotNone(retrieved_user) # it exists
+            self.assertEqual(retrieved_user.email, "test@example.com") #it matches the email
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Creates the in-memory sqlite3 testing enviroment with a single user test intended to showcase the enviroment works. Resolves #1. 
To test:
   -  Docker: Make sure your backend container is up and running, then run `make test`.
   - Local: Make sure you are using your Python virtual env (venv) and run `make local-test`
- Adds Make scripts to run testing both in the Docker container and locally. Additionally, adds logging of what the Make commands do when you run them. 
- Additional logging of the backend endpoint on hot reload.
- Adds venv to .gitignore so you can quickly access a virtual enviroment.