### PR TITLE
15 set up Flask CORS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,6 @@ POSTGRES_DB=postgres
 # Postgres access (Docker Only) -- http://localhost:8080/
 PGADMIN_DEFAULT_EMAIL=admin@example.com
 PGADMIN_DEFAULT_PASSWORD=admin
+
+# Frontend URL for CORS
+FRONTEND_URL=http://localhost:5173

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .env
 __pycache__
 venv/
+.vscode
+.mypy_cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy app files
 COPY . .
 
-EXPOSE 5000
+EXPOSE 3308
 
 # Use FLASK_ENV to determine whether to run in debug mode
-CMD ["flask", "run", "--host=0.0.0.0", "--port=5000"]
+CMD ["flask", "run", "--host=0.0.0.0", "--port=3308"]

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@ import os
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_migrate import Migrate
+from flask_cors import CORS
 from dotenv import load_dotenv
 
 # Load environment variables from .env
@@ -12,6 +13,7 @@ db = SQLAlchemy()
 
 def create_app():
     app = Flask(__name__)
+    CORS(app, origins=os.getenv("FRONTEND_URL"))
 
     # Read environment flag (default to "local" if not set)
     app_env = os.getenv("APP_ENV", "local").lower()
@@ -47,4 +49,4 @@ app = create_app()
 
 print(f"⚡ Running in {os.getenv('APP_ENV', 'local').upper()} mode")
 print(f"🔌 Connected to database: {app.config['SQLALCHEMY_DATABASE_URI']}")
-print(f"🌍 Running on http://0.0.0.0:{os.getenv('FLASK_RUN_PORT', '5000')}")
+print(f"🌍 Running on http://0.0.0.0:{os.getenv('FLASK_RUN_PORT', '3308')}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     restart: always
     env_file: .env
     ports:
-      - "5000:5000"
+      - "3308:3308"
     volumes:
       - .:/app
     environment:
@@ -15,9 +15,9 @@ services:
 # TO DO - fix the 'production' switch so that it works with production WSGI server
     command: >
       sh -c "if [ \"$FLASK_ENV\" = 'development' ]; then
-              flask run --host=0.0.0.0 --port=5000 --debug;
+              flask run --host=0.0.0.0 --port=3308 --debug;
             else
-              flask run --host=0.0.0.0 --port=5000;
+              flask run --host=0.0.0.0 --port=3308;
             fi"
 # This is our postgres database, the actual db
   db:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@
 Flask
 Flask-SQLAlchemy
 Flask-Migrate
+flask-cors
 psycopg2-binary
 python-dotenv


### PR DESCRIPTION
Issue: #15 

- This PR sets up CORS for the backend so that the frontend and backend can communicate in development and production. 
- It also changes the Flask port from 5000 to 3308 because I was having issues with 5000 seemingly being a popular port for other processes. (Please let me know if it needs to be on 5000 for some reason.) 

### Testing this out

- You may need to do `make clean` to reset things again
- Be sure to check out the additional environment variable added at the end of `.env.example` and update your own `.env`
- You may want to pull down the frontend PR request as well and try them out together