### PR TITLE
Send new JWT in responses to user PUT/PATCH [#36]

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -298,6 +298,16 @@ def update_user():
 
     # Commit to database
     db.session.commit()
+
+    # Generate JWT with user info (so the frontend can update 
+    # localStorage without requiring a full logout and login)
+    token = sign_token({
+        "id": user.id,
+        "email": user.email,
+        "first_name": user.first_name,
+        "last_name": user.last_name
+    })
+
     # Return new info
     return jsonify({
         "message": "User updated successfully",
@@ -308,7 +318,8 @@ def update_user():
             "first_name": user.first_name,
             "last_name": user.last_name,
             "password_hash": user.password_hash
-        }
+        },
+        "token": token,
     }), 200 # status = OK
 
 # Delete a User


### PR DESCRIPTION
Issue: #36 

This PR makes the small change of sending a new JWT back for user PUT/PATCH requests. This is necessary in the frontend to update user info in local storage without needing to log out and back in again. 

Frontend PR: https://github.com/CSPB3308-Team/productivity-frontend/pull/29