### PR TITLE
#49 -  `/streak` route + `/signup` Wallet linking

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -299,6 +299,14 @@ def signup():
         db.session.add(avatar)
         db.session.commit()
         print(f"Avatar '{avatar.avatar_name}' created!")
+
+        # Create Wallet
+        wallet = Wallets.query.filter_by(user_id = user.id).first()
+        if not wallet:
+            wallet = Wallets(user_id = user.id)
+            db.session.add(wallet)
+            db.session.commit()
+            print(f"Wallet {wallet.id} created for {user.email}!")
     else:
         # Conflict message
         print(f"User '{email}' already exists.")

--- a/app/routes.py
+++ b/app/routes.py
@@ -203,14 +203,14 @@ def delete_task():
 def get_streak():
     """Returns the current task completion streak in days"""
 
-    # Step 1: Auth
+    # Get auth token
     token = verify_token()
     if not token:
         return jsonify({"error": "Unauthorized or invalid token"}), 401
 
     user_id = token.get("id")
 
-    # Step 2: Get all completed tasks for user
+    # Get all tasks by user, that are complete, ordered by created date
     completed_tasks = (
         Tasks.query
         .filter_by(user_id=user_id, task_complete=True)

--- a/app/seed.py
+++ b/app/seed.py
@@ -60,6 +60,33 @@ def seed_tasks(user):
     else:
         print(f"Tasks for {user.username} already exist.")
 
+# Seeds a streak to Users
+def seed_streaks(user, number):
+    existing_streak = Tasks.query.filter_by(user_id=user.id, task_name="Get out of bed").first()
+    if not existing_streak:
+        # Get current data, empty arr
+        now_utc = datetime.now(timezone.utc)
+        streak_tasks = []
+        # Just iterate through and append different tasks each a day out
+        for i in range(number):
+            task_day = now_utc - timedelta(days=i)
+            streak_tasks.append(
+                Tasks(
+                    user_id=user.id,
+                    task_name="Get out of bed",
+                    created_date=task_day,
+                    due_date=task_day,
+                    task_renewed=False,
+                    task_complete=True,
+                    task_type="daily"
+                )
+            )
+        db.session.add_all(streak_tasks)
+        db.session.commit()
+        print(f"Seeded {number}-day streak for user {user.username}")
+    else:
+        print(f"Streak tasks already exist for user {user.username}")
+        
 # Seeds some default items
 def seed_items(item_type, name, model_key, item_cost):
     item = CustomizationItems.query.filter_by(name=name).first()
@@ -100,6 +127,11 @@ with app.app_context():
     seed_tasks(user1)
     seed_tasks(user2)
     seed_tasks(user3)
+
+    # Seed Streaks
+    seed_streaks(user1, 7)
+    seed_streaks(user2, 10)
+    seed_streaks(user1, 3)
 
     # Seed the Items
     # Seed Shirts


### PR DESCRIPTION
Adds the following:
- Updated `seed.py` data to create streaks for each seed User
- Adds `/streak`. Just pass the token via Authorization header and it'll return a calculated streak
- Defaults GET `/task` to return in order of due_date, due soonest first. Resolves https://github.com/CSPB3308-Team/productivity-backend/issues/50

Resolves #49 
---
- Also adds to `/signup` so that a new Wallet is automatically connected to a new User, resolves https://github.com/CSPB3308-Team/productivity-backend/issues/52

### Testing
- Seed Users
- Login as Users (user1, user2, user3 from seed)
- GET `/streak` passing the Authorization header, it'll return the streak
### Testing the new User Wallet creation:
- Create a new Account, you should see a log in the backend: `Wallet <id> created for <email>!`
- You can also check pgAdmin for the wallet to appear